### PR TITLE
Improve popover positioning

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -92,24 +92,24 @@
               <em v-b-popover.hover.bottom="'gm gm gm'">Magical Internet Money</em>
             </b-navbar-brand>
             <b-navbar-nav class="ml-auto">
-              <!-- <b-nav-item size="sm" to="/" active-class="active" v-b-popover.hover="'Welcome'">Home</b-nav-item> -->
-              <b-nav-item size="sm" to="/addresses" active-class="active" v-b-popover.hover="'View/edit addresses'">Addresses</b-nav-item>
-              <b-nav-item size="sm" to="/fungibleTokens" active-class="active" v-b-popover.hover="'ERC-20 Fungible Tokens'">Fungible Tokens</b-nav-item>
-              <b-nav-item size="sm" to="/nonFungibleTokens" active-class="active" v-b-popover.hover="'ERC-721 and ERC-1155 Non-Fungible Tokens'">Non-Fungible Tokens</b-nav-item>
-              <b-nav-item size="sm" to="/registry" active-class="active" v-b-popover.hover="'Registry of Addresses to Stealth Meta-Addresses'">Registry</b-nav-item>
-              <b-nav-item size="sm" to="/stealthtransfers" active-class="active" v-b-popover.hover="'Stealth Transfers'">Stealth Transfers</b-nav-item>
-              <b-nav-item size="sm" to="/config" active-class="active" v-b-popover.hover="'Configuration'">Config</b-nav-item>
+              <!-- <b-nav-item size="sm" to="/" active-class="active" v-b-popover.hover.bottom="'Welcome'">Home</b-nav-item> -->
+              <b-nav-item size="sm" to="/addresses" active-class="active" v-b-popover.hover.bottom="'View/edit addresses'">Addresses</b-nav-item>
+              <b-nav-item size="sm" to="/fungibleTokens" active-class="active" v-b-popover.hover.bottom="'ERC-20 Fungible Tokens'">Fungible Tokens</b-nav-item>
+              <b-nav-item size="sm" to="/nonFungibleTokens" active-class="active" v-b-popover.hover.bottom="'ERC-721 and ERC-1155 Non-Fungible Tokens'">Non-Fungible Tokens</b-nav-item>
+              <b-nav-item size="sm" to="/registry" active-class="active" v-b-popover.hover.bottom="'Registry of Addresses to Stealth Meta-Addresses'">Registry</b-nav-item>
+              <b-nav-item size="sm" to="/stealthtransfers" active-class="active" v-b-popover.hover.bottom="'Stealth Transfers'">Stealth Transfers</b-nav-item>
+              <b-nav-item size="sm" to="/config" active-class="active" v-b-popover.hover.bottom="'Configuration'">Config</b-nav-item>
               <b-nav-form>
-                <b-button size="sm" variant="link" class="ml-4" v-b-popover.hover="'Power up this app'" @click="setPowerOn();" v-if="!powerOn"><b-icon-power shift-v="-1" font-scale="1.5"></b-icon-power></b-button>
-                <b-button size="sm" variant="link" v-b-popover.hover="'Show status'" v-b-toggle.sidebar-status v-if="powerOn"><b-icon-layout-sidebar-reverse class="ml-4 mr-2" shift-v="-1" font-scale="1.3"></b-icon-layout-sidebar-reverse><b-spinner class="m-0" :variant="spinnerVariant" v-if="powerOn" style="animation: spinner-grow 3.75s linear infinite;" small type="grow" label="Spinning"></b-spinner></b-button>
+                <b-button size="sm" variant="link" class="ml-4" v-b-popover.hover.bottom="'Power up this app'" @click="setPowerOn();" v-if="!powerOn"><b-icon-power shift-v="-1" font-scale="1.5"></b-icon-power></b-button>
+                <b-button size="sm" variant="link" v-b-popover.hover.bottom="'Show status'" v-b-toggle.sidebar-status v-if="powerOn"><b-icon-layout-sidebar-reverse class="ml-4 mr-2" shift-v="-1" font-scale="1.3"></b-icon-layout-sidebar-reverse><b-spinner class="m-0" :variant="spinnerVariant" v-if="powerOn" style="animation: spinner-grow 3.75s linear infinite;" small type="grow" label="Spinning"></b-spinner></b-button>
                 <b-sidebar id="sidebar-status" v-model="statusSidebar" title="Status" width="400px" right shadow no-header-close header-class="m-0 p-0">
                   <template v-slot:title="{ hide }">
                     <div class="d-flex flex-row justify-content-between m-0 p-0" style="height: 37px;">
                       <div class="m-0 p-0">
-                        <b-button size="sm" variant="link" class="m-0 p-0" v-b-popover.hover="'Close sidebar'" @click="hide"><b-icon-x shift-v="-1" font-scale="1.7"></b-icon-x></b-button>
+                        <b-button size="sm" variant="link" class="m-0 p-0" v-b-popover.hover.bottom="'Close sidebar'" @click="hide"><b-icon-x shift-v="-1" font-scale="1.7"></b-icon-x></b-button>
                       </div>
                       <div class="m-0 p-0">
-                        <b-button size="sm" variant="link" class="m-0 p-0" v-b-popover.hover="'Power down this app'" @click="setPowerOff();" v-if="powerOn"><b-icon-power shift-v="-1" font-scale="1.5"></b-icon-power></b-button>
+                        <b-button size="sm" variant="link" class="m-0 p-0" v-b-popover.hover.bottom="'Power down this app'" @click="setPowerOff();" v-if="powerOn"><b-icon-power shift-v="-1" font-scale="1.5"></b-icon-power></b-button>
                       </div>
                       <div class="m-0 p-0 pt-2 pl-4">
                         <h5>Status</h5>
@@ -132,7 +132,7 @@
           <b-card no-header no-body class="m-0 p-0 border-0">
             <b-card-body class="m-0 p-0">
               <b-alert v-if="chainId && chainId != 1 && chainId != 11155111" size="sm" variant="warning" show class="m-1 mb-2 px-2 py-1">
-                Please install the MetaMask extension, connect to the Sepolia testnet and refresh this page. Then click <b-button size="sm" variant="link" class="m-0 p-0" v-b-popover.hover="'Power up this app'" @click="setPowerOn();"><b-icon-power shift-v="-1" font-scale="1.5"></b-icon-power></b-button> on the top right. <br />You will be able to sync your testnet addresses to Ethereum mainnet ENS names shortly.
+                Please install the MetaMask extension, connect to the Sepolia testnet and refresh this page. Then click <b-button size="sm" variant="link" class="m-0 p-0" v-b-popover.hover.top="'Power up this app'" @click="setPowerOn();"><b-icon-power shift-v="-1" font-scale="1.5"></b-icon-power></b-button> on the top right. <br />You will be able to sync your testnet addresses to Ethereum mainnet ENS names shortly.
               </b-alert>
             </b-card-body>
           </b-card>


### PR DESCRIPTION
## Motivation

It's hard to switch between the top bar items because the popovers appear fast, horizontally.

This behavior prevents the neighboring item from being clicked on.

## Solution

This PR changes the positioning of the popovers to appear below.

For the same reason, the positioning of one other popover has been changed to appear above.